### PR TITLE
build: use SCM version for the project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ plugins {
   id 'net.neoforged.gradle.userdev' version '7.0.184'
 }
 
+apply from: 'version.gradle'
+
 tasks.named('wrapper', Wrapper).configure {
   // Define wrapper values here so as to not have to always do so when updating gradlew.properties.
   // Switching this to Wrapper.DistributionType.ALL will download the full gradle sources that comes with
@@ -13,10 +15,10 @@ tasks.named('wrapper', Wrapper).configure {
   distributionType = Wrapper.DistributionType.BIN
 }
 
+// The calculated mod version
+def mod_version = "${project.scm_version}"
 version = mod_version
-group = mod_group_id
-
-version = mod_version
+print("Building ${version}...\n")
 group = mod_group_id
 
 repositories {


### PR DESCRIPTION
# Description

THe project version is now calculated from the SCM. The latest git tag (`git describe`) is used to find the current version.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [x] Other

## Checklist

- [x] Code compiles and tests pass
- [x] Documentation is up to date
- [x] I have read the contribution guide

Closes #
